### PR TITLE
Use a nullable type, fix todo

### DIFF
--- a/src/test/kotlin/io/eddumelendez/reactorkotlin/Part08OtherOperations.kt
+++ b/src/test/kotlin/io/eddumelendez/reactorkotlin/Part08OtherOperations.kt
@@ -97,13 +97,13 @@ class Part08OtherOperations {
                 .expectNext(User.SKYLER)
                 .verifyComplete()
 
-        mono = nullAwareUserToMono(null!!)
+        mono = nullAwareUserToMono(null)
         mono.test()
                 .verifyComplete()
     }
 
     // TODO Return a valid Mono of user for null input and non null input user (hint: Reactive Streams does not accept null values)
-    fun nullAwareUserToMono(user: User): Mono<User> {
+    fun nullAwareUserToMono(user: User?): Mono<User> {
         return null!!
     }
 

--- a/src/test/kotlin/io/eddumelendez/reactorkotlin/Part10ReactiveToBlocking.kt
+++ b/src/test/kotlin/io/eddumelendez/reactorkotlin/Part10ReactiveToBlocking.kt
@@ -21,7 +21,7 @@ class Part10ReactiveToBlocking {
     }
 
     // TODO Return the user contained in that Mono
-    fun monoToValue(mono: Mono<User>): User {
+    fun monoToValue(mono: Mono<User>): User? {
         return null!!
     }
 

--- a/src/test/kotlin/io/eddumelendez/reactorkotlin/Part11BlockingToReactive.kt
+++ b/src/test/kotlin/io/eddumelendez/reactorkotlin/Part11BlockingToReactive.kt
@@ -44,7 +44,7 @@ class Part11BlockingToReactive {
         assertFalse(it.hasNext())
     }
 
-    // TODO Insert users contained in the Flux parameter in the blocking repository using an parallel scheduler and return a Mono<Void> that signal the end of the operation
+    // TODO Insert users contained in the Flux parameter in the blocking repository using an elastic scheduler and return a Mono<Void> that signal the end of the operation
     fun fluxToBlockingRepository(flux: Flux<User>, repository: BlockingRepository<User>): Mono<Void> {
         return null!!
     }


### PR DESCRIPTION
 - Some tests throw a nullpointer outside the `TODO` and it can be confuse to the developer. So in these cases it was replaced by a nullable type.
 - The `Schedullers.parallel()` throws an `IllegalStateException` when you try to run a blocking code inside it.  So the TODO description was updated to use `Schedullers.elastic()`