### PR TITLE
Fix TODO description

### DIFF
--- a/src/test/kotlin/io/eddumelendez/reactorkotlin/Part11BlockingToReactive.kt
+++ b/src/test/kotlin/io/eddumelendez/reactorkotlin/Part11BlockingToReactive.kt
@@ -47,7 +47,7 @@ class Part11BlockingToReactive {
         assertFalse(it.hasNext())
     }
 
-    // TODO Insert users contained in the Flux parameter in the blocking repository using an parallel scheduler and return a Mono<Void> that signal the end of the operation
+    // TODO Insert users contained in the Flux parameter in the blocking repository using an elastic scheduler and return a Mono<Void> that signal the end of the operation
     fun fluxToBlockingRepository(flux: Flux<User>, repository: BlockingRepository<User>): Mono<Void> {
         return flux.publishOn(Schedulers.elastic())
                 .doOnNext({ repository.save(it) })


### PR DESCRIPTION
 - The `Schedullers.parallel()` throws an `IllegalStateException` when you try to run a blocking code inside it.  So the TODO description was updated to use `Schedullers.elastic()`